### PR TITLE
スライドのリンクの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@
 
 ### [Gitの操作(応用編)](practice_advanced/README.md)
 
-* [講義スライド](https://speakerdeck.com/kaityo256/github-practice-github-basic)
+* [講義スライド](https://speakerdeck.com/kaityo256/github-practice-advanced)
 * `git amend`によりコミットが変更されることを確認する
 * `git merge`の衝突を解決する
 * `git rebase`により歴史を改変する

--- a/index.html
+++ b/index.html
@@ -183,7 +183,7 @@
 </ul>
 <h3 id="gitの操作応用編"><a href="practice_advanced/index.html">Gitの操作(応用編)</a></h3>
 <ul>
-<li><a href="https://speakerdeck.com/kaityo256/github-practice-github-basic">講義スライド</a></li>
+<li><a href="https://speakerdeck.com/kaityo256/github-practice-advanced">講義スライド</a></li>
 <li><code>git amend</code>によりコミットが変更されることを確認する</li>
 <li><code>git merge</code>の衝突を解決する</li>
 <li><code>git rebase</code>により歴史を改変する</li>


### PR DESCRIPTION
README.md と index.html にある「Gitの操作(応用編)」のスライドへのリンクが「GitHubの操作(基本編)」のものになっていたので、修正しました。
置き換え後URL -> https://speakerdeck.com/kaityo256/github-practice-advanced
